### PR TITLE
testnet config for wallet, this is ugly, do not use

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/go-socks/socks"
 	"github.com/btcsuite/websocket"
 )
@@ -178,6 +179,10 @@ type Client struct {
 	disconnect      chan struct{}
 	shutdown        chan struct{}
 	wg              sync.WaitGroup
+}
+
+func (c *Client) DefaultNet() *chaincfg.Params {
+	return c.config.DefaultNet
 }
 
 // NextID returns the next id to be used when sending a JSON-RPC message.  This
@@ -1139,6 +1144,7 @@ type ConnConfig struct {
 	// EnableBCInfoHacks is an option provided to enable compatibility hacks
 	// when connecting to blockchain.info RPC server
 	EnableBCInfoHacks bool
+	DefaultNet        *chaincfg.Params
 }
 
 // newHTTPClient returns a new http client that is configured according to the

--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -758,7 +758,7 @@ type FutureAddMultisigAddressResult chan *response
 // Receive waits for the response promised by the future and returns the
 // multisignature address that requires the specified number of signatures for
 // the provided addresses.
-func (r FutureAddMultisigAddressResult) Receive() (btcutil.Address, error) {
+func (r FutureAddMultisigAddressResult) Receive(defaultNet *chaincfg.Params) (btcutil.Address, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return nil, err
@@ -771,7 +771,7 @@ func (r FutureAddMultisigAddressResult) Receive() (btcutil.Address, error) {
 		return nil, err
 	}
 
-	return btcutil.DecodeAddress(addr, &chaincfg.MainNetParams)
+	return btcutil.DecodeAddress(addr, defaultNet)
 }
 
 // AddMultisigAddressAsync returns an instance of a type that can be used to get
@@ -793,7 +793,7 @@ func (c *Client) AddMultisigAddressAsync(requiredSigs int, addresses []btcutil.A
 // number of signatures for the provided addresses to the wallet.
 func (c *Client) AddMultisigAddress(requiredSigs int, addresses []btcutil.Address, account string) (btcutil.Address, error) {
 	return c.AddMultisigAddressAsync(requiredSigs, addresses,
-		account).Receive()
+		account).Receive(c.DefaultNet())
 }
 
 // FutureCreateMultisigResult is a future promise to deliver the result of a
@@ -872,7 +872,7 @@ type FutureGetNewAddressResult chan *response
 
 // Receive waits for the response promised by the future and returns a new
 // address.
-func (r FutureGetNewAddressResult) Receive() (btcutil.Address, error) {
+func (r FutureGetNewAddressResult) Receive(defaultNet *chaincfg.Params) (btcutil.Address, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return nil, err
@@ -885,7 +885,7 @@ func (r FutureGetNewAddressResult) Receive() (btcutil.Address, error) {
 		return nil, err
 	}
 
-	return btcutil.DecodeAddress(addr, &chaincfg.MainNetParams)
+	return btcutil.DecodeAddress(addr, defaultNet)
 }
 
 // GetNewAddressAsync returns an instance of a type that can be used to get the
@@ -900,7 +900,7 @@ func (c *Client) GetNewAddressAsync(account string) FutureGetNewAddressResult {
 
 // GetNewAddress returns a new address.
 func (c *Client) GetNewAddress(account string) (btcutil.Address, error) {
-	return c.GetNewAddressAsync(account).Receive()
+	return c.GetNewAddressAsync(account).Receive(c.DefaultNet())
 }
 
 // FutureGetRawChangeAddressResult is a future promise to deliver the result of
@@ -910,7 +910,7 @@ type FutureGetRawChangeAddressResult chan *response
 // Receive waits for the response promised by the future and returns a new
 // address for receiving change that will be associated with the provided
 // account.  Note that this is only for raw transactions and NOT for normal use.
-func (r FutureGetRawChangeAddressResult) Receive() (btcutil.Address, error) {
+func (r FutureGetRawChangeAddressResult) Receive(defaultNet *chaincfg.Params) (btcutil.Address, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return nil, err
@@ -923,7 +923,7 @@ func (r FutureGetRawChangeAddressResult) Receive() (btcutil.Address, error) {
 		return nil, err
 	}
 
-	return btcutil.DecodeAddress(addr, &chaincfg.MainNetParams)
+	return btcutil.DecodeAddress(addr, defaultNet)
 }
 
 // GetRawChangeAddressAsync returns an instance of a type that can be used to
@@ -940,7 +940,7 @@ func (c *Client) GetRawChangeAddressAsync(account string) FutureGetRawChangeAddr
 // associated with the provided account.  Note that this is only for raw
 // transactions and NOT for normal use.
 func (c *Client) GetRawChangeAddress(account string) (btcutil.Address, error) {
-	return c.GetRawChangeAddressAsync(account).Receive()
+	return c.GetRawChangeAddressAsync(account).Receive(c.DefaultNet())
 }
 
 // FutureAddWitnessAddressResult is a future promise to deliver the result of
@@ -949,7 +949,7 @@ type FutureAddWitnessAddressResult chan *response
 
 // Receive waits for the response promised by the future and returns the new
 // address.
-func (r FutureAddWitnessAddressResult) Receive() (btcutil.Address, error) {
+func (r FutureAddWitnessAddressResult) Receive(defaultNet *chaincfg.Params) (btcutil.Address, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return nil, err
@@ -962,7 +962,7 @@ func (r FutureAddWitnessAddressResult) Receive() (btcutil.Address, error) {
 		return nil, err
 	}
 
-	return btcutil.DecodeAddress(addr, &chaincfg.MainNetParams)
+	return btcutil.DecodeAddress(addr, defaultNet)
 }
 
 // AddWitnessAddressAsync returns an instance of a type that can be used to get
@@ -978,7 +978,7 @@ func (c *Client) AddWitnessAddressAsync(address string) FutureAddWitnessAddressR
 // AddWitnessAddress adds a witness address for a script and returns the new
 // address (P2SH of the witness script).
 func (c *Client) AddWitnessAddress(address string) (btcutil.Address, error) {
-	return c.AddWitnessAddressAsync(address).Receive()
+	return c.AddWitnessAddressAsync(address).Receive(c.DefaultNet())
 }
 
 // FutureGetAccountAddressResult is a future promise to deliver the result of a
@@ -987,7 +987,7 @@ type FutureGetAccountAddressResult chan *response
 
 // Receive waits for the response promised by the future and returns the current
 // Bitcoin address for receiving payments to the specified account.
-func (r FutureGetAccountAddressResult) Receive() (btcutil.Address, error) {
+func (r FutureGetAccountAddressResult) Receive(defaultNet *chaincfg.Params) (btcutil.Address, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return nil, err
@@ -1000,7 +1000,7 @@ func (r FutureGetAccountAddressResult) Receive() (btcutil.Address, error) {
 		return nil, err
 	}
 
-	return btcutil.DecodeAddress(addr, &chaincfg.MainNetParams)
+	return btcutil.DecodeAddress(addr, defaultNet)
 }
 
 // GetAccountAddressAsync returns an instance of a type that can be used to get
@@ -1016,7 +1016,7 @@ func (c *Client) GetAccountAddressAsync(account string) FutureGetAccountAddressR
 // GetAccountAddress returns the current Bitcoin address for receiving payments
 // to the specified account.
 func (c *Client) GetAccountAddress(account string) (btcutil.Address, error) {
-	return c.GetAccountAddressAsync(account).Receive()
+	return c.GetAccountAddressAsync(account).Receive(c.DefaultNet())
 }
 
 // FutureGetAccountResult is a future promise to deliver the result of a
@@ -1090,7 +1090,7 @@ type FutureGetAddressesByAccountResult chan *response
 
 // Receive waits for the response promised by the future and returns the list of
 // addresses associated with the passed account.
-func (r FutureGetAddressesByAccountResult) Receive() ([]btcutil.Address, error) {
+func (r FutureGetAddressesByAccountResult) Receive(defaultNet *chaincfg.Params) ([]btcutil.Address, error) {
 	res, err := receiveFuture(r)
 	if err != nil {
 		return nil, err
@@ -1106,7 +1106,7 @@ func (r FutureGetAddressesByAccountResult) Receive() ([]btcutil.Address, error) 
 	addrs := make([]btcutil.Address, 0, len(addrStrings))
 	for _, addrStr := range addrStrings {
 		addr, err := btcutil.DecodeAddress(addrStr,
-			&chaincfg.MainNetParams)
+			defaultNet)
 		if err != nil {
 			return nil, err
 		}
@@ -1129,7 +1129,7 @@ func (c *Client) GetAddressesByAccountAsync(account string) FutureGetAddressesBy
 // GetAddressesByAccount returns the list of addresses associated with the
 // passed account.
 func (c *Client) GetAddressesByAccount(account string) ([]btcutil.Address, error) {
-	return c.GetAddressesByAccountAsync(account).Receive()
+	return c.GetAddressesByAccountAsync(account).Receive(c.DefaultNet())
 }
 
 // FutureMoveResult is a future promise to deliver the result of a MoveAsync,


### PR DESCRIPTION
This is a quick hack to be able to use testnet with btcwallet rpc.